### PR TITLE
feat: style prop overrides default styles, does not replace

### DIFF
--- a/example/src/example.js
+++ b/example/src/example.js
@@ -65,6 +65,31 @@ var App = React.createClass({
           </div>
         </section>
 
+        <section className="section">
+          <h2 className="demo-heading"> Overriding inline-styles </h2>
+          <div className="demo-block">
+            <Media style={{ color: 'red', fontWeight: 'bold' }}>
+              <Img href="http://twitter.com/chantastic" style={{ border: '1px solid navy', borderRadius: '50%', overflow: 'hidden' }}>
+                <ImgExt
+                 src="http://0.gravatar.com/avatar/d56966cb85dc4153ceeec7ca0bdb568e"
+                 alt="chantastic"
+                 style={{transform: 'rotateX(180deg)', borderRadius: '50%'}}
+                />
+              </Img>
+
+              <Bd>
+                I've spent most of my career focused on taming styles in CSS. I
+                saw it as a problem that would never be solved. Then, #reactjs
+                happened.
+                <div>
+                  <a href="http://twitter.com/chantastic">@chantastic</a>
+                  <span className="detail"> 7 hours ago</span>
+                </div>
+              </Bd>
+            </Media>
+          </div>
+        </section>
+
         <h2 className="demo-heading"> TODO </h2>
         <ul>
           <li>Why doesn't instanceOf work as expected?</li>

--- a/src/ReactMediaObject.js
+++ b/src/ReactMediaObject.js
@@ -30,9 +30,17 @@ const mediaStyles = {
 };
 
 class Media extends Component {
+  get style () {
+    return Object.assign(
+      {},
+      mediaStyles.root,
+      this.props.style
+    );
+  }
+
   render() {
     return (
-      <div className="media" style={mediaStyles.root} {...this.props}>
+      <div className="media" {...this.props} style={this.style}>
         <div style={clearfixStyles[':before']} />
         {this.props.children}
         <div style={clearfixStyles[':after']} />
@@ -42,29 +50,48 @@ class Media extends Component {
 }
 
 Media.propTypes = {
-  children: PropTypes.node.isRequired
+  children: PropTypes.node.isRequired,
+  style: PropTypes.object
 };
 
 class Img extends Component {
+  get style () {
+    return Object.assign(
+      {},
+      mediaStyles.img,
+      this.props.style
+    );
+  }
+
   render () {
-    return <a className="img" style={mediaStyles.img} {...this.props} />;
+    return <a className="img" {...this.props} style={this.style} />;
   }
 }
 
 Img.propTypes = {
   children: PropTypes.node.isRequired,
-  href: PropTypes.string.isRequired
+  href: PropTypes.string.isRequired,
+  style: PropTypes.object
 };
 
 class ImgExt extends Component {
+  get style () {
+    return Object.assign(
+      {},
+      mediaStyles.imgExt,
+      this.props.style
+    );
+  }
+
   render () {
-    return <img style={mediaStyles.imgExt} {...this.props} />;
+    return <img {...this.props} style={this.style} />;
   }
 }
 
 ImgExt.propTypes = {
   alt: PropTypes.string.isRequired,
-  src: PropTypes.string.isRequired
+  src: PropTypes.string.isRequired,
+  style: PropTypes.object
 };
 
 class Bd extends Component {


### PR DESCRIPTION
## Issue:

It's nice to retain default styles when passing in a `styles` object as props. Right now, passing in an object obliterates the inline-styles.
## Job Story:

When I pass in a `style` object to any `ReactMedia` component, I want those styles merged atop the default inline-styles, so that I don't have to re-write all of the provided styles.
## Solution:

Add a `style` resolver function to each component, using Object.assign. Place constructed styles after `{...this.props}` spread.
## Side Effects:

It's now more difficulty to replace styles. The only way to do so is to provide the props you'd like to replace. This isn't a big deal for small style objects but can be cumbersome as styles grow.

I've been playing with a `noStyle` prop, which I have mixed feelings about. But it does the trick of obliterating default styles.
## References, ticket, issues:

Resolves #8
