### PR TITLE
feature(Img): add reverse prop for right-alignment

### DIFF
--- a/example/src/example.js
+++ b/example/src/example.js
@@ -93,8 +93,8 @@ var App = React.createClass({
         <section className="section">
           <h2 className="demo-heading"> Right-aligned Img</h2>
           <div className="demo-block">
-            <Media>
-              <Img href="http://twitter.com/chantastic" reverse>
+            <Media reverse>
+              <Img href="http://twitter.com/chantastic">
                 <ImgExt
                  src="http://0.gravatar.com/avatar/d56966cb85dc4153ceeec7ca0bdb568e"
                  alt="chantastic"

--- a/example/src/example.js
+++ b/example/src/example.js
@@ -90,6 +90,30 @@ var App = React.createClass({
           </div>
         </section>
 
+        <section className="section">
+          <h2 className="demo-heading"> Right-aligned Img</h2>
+          <div className="demo-block">
+            <Media>
+              <Img href="http://twitter.com/chantastic" reverse>
+                <ImgExt
+                 src="http://0.gravatar.com/avatar/d56966cb85dc4153ceeec7ca0bdb568e"
+                 alt="chantastic"
+                />
+              </Img>
+
+              <Bd>
+                I've spent most of my career focused on taming styles in CSS. I
+                saw it as a problem that would never be solved. Then, #reactjs
+                happened.
+                <div>
+                  <a href="http://twitter.com/chantastic">@chantastic</a>
+                  <span className="detail"> 7 hours ago</span>
+                </div>
+              </Bd>
+            </Media>
+          </div>
+        </section>
+
         <h2 className="demo-heading"> TODO </h2>
         <ul>
           <li>Why doesn't instanceOf work as expected?</li>

--- a/src/Img.js
+++ b/src/Img.js
@@ -1,15 +1,16 @@
 import React, { Component, PropTypes } from 'react';
 
-const styles = {
-  float: 'left',
-  marginRight: 10
-};
+function styles (reversed) {
+  return (reversed)
+    ? { float: 'right', marginLeft: 10 }
+    : { float: 'left', marginRight: 10 };
+}
 
 class Img extends Component {
   get style () {
     return Object.assign(
       {},
-      styles,
+      styles(this.props.reverse),
       this.props.style
     );
   }
@@ -22,6 +23,7 @@ class Img extends Component {
 Img.propTypes = {
   children: PropTypes.node.isRequired,
   href: PropTypes.string.isRequired,
+  reverse: PropTypes.bool,
   style: PropTypes.object
 };
 

--- a/src/Img.js
+++ b/src/Img.js
@@ -10,12 +10,13 @@ class Img extends Component {
   get style () {
     return Object.assign(
       {},
-      styles(this.props.reverse),
+      styles(this.context.reverse),
       this.props.style
     );
   }
 
   render () {
+    console.log(this.context);
     return <a className="img" {...this.props} style={this.style} />;
   }
 }
@@ -23,8 +24,11 @@ class Img extends Component {
 Img.propTypes = {
   children: PropTypes.node.isRequired,
   href: PropTypes.string.isRequired,
-  reverse: PropTypes.bool,
   style: PropTypes.object
+};
+
+Img.contextTypes = {
+  reverse: PropTypes.bool
 };
 
 export default Img;

--- a/src/Media.js
+++ b/src/Media.js
@@ -16,6 +16,9 @@ const styles = {
 };
 
 class Media extends Component {
+  getChildContext () {
+    return { reverse: this.props.reverse };
+  }
 
   get style () {
     return Object.assign(
@@ -38,7 +41,12 @@ class Media extends Component {
 
 Media.propTypes = {
   children: PropTypes.node.isRequired,
+  reverse: PropTypes.bool,
   style: PropTypes.object
+};
+
+Media.childContextTypes = {
+  reverse: PropTypes.bool
 };
 
 export default Media;


### PR DESCRIPTION
Issue:

Now simple way to right-align Img.

Job Story:

When I'm showing a chat conversation, I want to right-align the Img, So
that I can demonstrate sides of a conversation.

Solution:

Add `reverse` prop to Img that flips float styles.

Outcome/side effects:

The way I'm spreading `props` every nested component gets the `reverse` prop.

References, ticket, issues:

Resolves #9
