### PR TITLE
href shouldn't be required

### DIFF
--- a/src/Img.js
+++ b/src/Img.js
@@ -19,6 +19,6 @@ export default class Img extends Component {
 
 Img.propTypes = {
   children: PropTypes.node.isRequired,
-  href: PropTypes.string.isRequired,
+  href: PropTypes.string,
   style: PropTypes.object
 };


### PR DESCRIPTION
I often don't want the media object image linked to anything.
